### PR TITLE
Using kfree_sensitive over kzfree for kernels >= 5.9-rc1

### DIFF
--- a/hid-tminit.c
+++ b/hid-tminit.c
@@ -15,14 +15,7 @@
 #include <linux/input.h>
 #include <linux/slab.h>
 #include <linux/module.h>
-#include <linux/version.h>
 #include "hid-tminit.h"
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,1)
-	#define KFREE(ptr) kfree_sensitive(ptr)
-#else
-	#define KFREE(ptr) kzfree(ptr)
-#endif
 
 /**
  * On some setups initializing the T300RS crashes the kernel,
@@ -61,7 +54,7 @@ static void tminit_interrupts(struct hid_device *hdev){
 		}
 	}
 
-	KFREE(send_buf);
+	kfree(send_buf);
 }
 
 static void tminit_change_handler(struct urb *urb)
@@ -142,10 +135,10 @@ static void tminit_remove(struct hid_device *hdev)
 
 	usb_kill_urb(tm_wheel->urb);
 
-	KFREE(tm_wheel->response);
-	KFREE(tm_wheel->model_request);
+	kfree(tm_wheel->response);
+	kfree(tm_wheel->model_request);
 	usb_free_urb(tm_wheel->urb);
-	KFREE(tm_wheel);
+	kfree(tm_wheel);
 
 	hid_hw_stop(hdev);
 }
@@ -234,10 +227,10 @@ static int tminit_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 	return ret;
 
-error5: KFREE(tm_wheel->response);
-error4:	KFREE(tm_wheel->model_request);
+error5: kfree(tm_wheel->response);
+error4:	kfree(tm_wheel->model_request);
 error3:	usb_free_urb(tm_wheel->urb);
-error2:	KFREE(tm_wheel);
+error2:	kfree(tm_wheel);
 error1:	hid_hw_stop(hdev);
 error0:
 	return ret; 

--- a/hid-tminit.c
+++ b/hid-tminit.c
@@ -15,7 +15,14 @@
 #include <linux/input.h>
 #include <linux/slab.h>
 #include <linux/module.h>
+#include <linux/version.h>
 #include "hid-tminit.h"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,1)
+	#define KFREE(ptr) kfree_sensitive(ptr)
+#else
+	#define KFREE(ptr) kzfree(ptr)
+#endif
 
 /**
  * On some setups initializing the T300RS crashes the kernel,
@@ -54,7 +61,7 @@ static void tminit_interrupts(struct hid_device *hdev){
 		}
 	}
 
-	kzfree(send_buf);
+	KFREE(send_buf);
 }
 
 static void tminit_change_handler(struct urb *urb)
@@ -135,10 +142,10 @@ static void tminit_remove(struct hid_device *hdev)
 
 	usb_kill_urb(tm_wheel->urb);
 
-	kzfree(tm_wheel->response);
-	kzfree(tm_wheel->model_request);
+	KFREE(tm_wheel->response);
+	KFREE(tm_wheel->model_request);
 	usb_free_urb(tm_wheel->urb);
-	kzfree(tm_wheel);
+	KFREE(tm_wheel);
 
 	hid_hw_stop(hdev);
 }
@@ -227,10 +234,10 @@ static int tminit_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 	return ret;
 
-error5: kzfree(tm_wheel->response);
-error4:	kzfree(tm_wheel->model_request);
+error5: KFREE(tm_wheel->response);
+error4:	KFREE(tm_wheel->model_request);
 error3:	usb_free_urb(tm_wheel->urb);
-error2:	kzfree(tm_wheel);
+error2:	KFREE(tm_wheel);
 error1:	hid_hw_stop(hdev);
 error0:
 	return ret; 


### PR DESCRIPTION
This modification is needed for the newer kernels as per https://github.com/torvalds/linux/commit/453431a54934d917153c65211b2dabf45562ca88

What I have done is tested on kernel version `5.10.5-arch1-1` but should work for all other kernels from and above `5.9.1`