### PR TITLE
Initialize with base info rather than base + attachment

### DIFF
--- a/hid-tminit.c
+++ b/hid-tminit.c
@@ -83,7 +83,7 @@ static void tminit_model_handler(struct urb *urb)
 {
 	struct hid_device *hdev = urb->context;
 	struct tm_wheel *tm_wheel = hid_get_drvdata(hdev);
-	uint16_t model = 0;
+	uint8_t model = 0;
 	int i, ret;
 	const struct tm_wheel_info *twi = 0;
 
@@ -93,20 +93,20 @@ static void tminit_model_handler(struct urb *urb)
 	}
 
 	if (tm_wheel->response->type == cpu_to_le16(0x49))
-		model = le16_to_cpu(tm_wheel->response->data.a.model);
+		model = tm_wheel->response->data.a.model;
 	else if (tm_wheel->response->type == cpu_to_le16(0x47))
-		model = le16_to_cpu(tm_wheel->response->data.b.model);
+		model = tm_wheel->response->data.b.model;
 	else {
 		hid_err(hdev, "Unknown packet type 0x%x, unable to proceed further with wheel init\n", tm_wheel->response->type);
 		return;
 	}
 
 	for (i = 0; i < tm_wheels_infos_length && !twi; i++)
-		if (tm_wheels_infos[i].wheel_type == model)
+		if (tm_wheels_infos[i].model == model)
 			twi = tm_wheels_infos + i;
 
 	if (twi)
-		hid_info(hdev, "Wheel with model id 0x%x is a %s\n", model, twi->wheel_name);
+		hid_info(hdev, "Wheel with model 0x%x is a %s\n", model, twi->wheel_name);
 	else {
 		hid_err(hdev, "Unknown wheel's model id 0x%x, unable to proceed further with wheel init\n", model);
 		return;

--- a/hid-tminit.h
+++ b/hid-tminit.h
@@ -27,7 +27,8 @@ static const unsigned int setup_arr_sizes[] = {
  * and vice-versa
  */
 struct tm_wheel_info {
-	uint16_t wheel_type;
+	uint8_t model;
+	uint8_t attachment;
 
 	/**
 	 * See when the USB control out packet is prepared...
@@ -43,14 +44,15 @@ struct tm_wheel_info {
  * Note: TMX does not work as it requires 2 control packets
  */
 static const struct tm_wheel_info tm_wheels_infos[] = {
-	{0x0306, 0x0006, "Thrustmaster T150RS"},
-	{0x0206, 0x0005, "Thrustmaster T300RS"},
-	{0x0204, 0x0005, "Thrustmaster T300 Ferrari Alcantara Edition"},
-	{0x0002, 0x0002, "Thrustmaster T500RS"},
-	{0x0407, 0x0001, "Thrustmaster TMX"}
+	{0x03, 0x06, 0x0006, "Thrustmaster T150RS"},
+	{0x02, 0x06, 0x0005, "Thrustmaster T300RS"},
+	{0x02, 0x03, 0x0005, "Thrustmaster T300RS (F1 attachment)"},
+	{0x02, 0x04, 0x0005, "Thrustmaster T300 Ferrari Alcantara Edition"},
+	{0x00, 0x02, 0x0002, "Thrustmaster T500RS"},
+	{0x04, 0x07, 0x0001, "Thrustmaster TMX"}
 };
 
-static const uint8_t tm_wheels_infos_length = 5;
+static const uint8_t tm_wheels_infos_length = 6;
 
 /**
  * This structs contains (in little endian) the response data
@@ -77,7 +79,8 @@ struct __packed tm_wheel_response
 			 * Seems to be the model code of the wheel
 			 * Read table thrustmaster_wheels to values
 			 */
-			uint16_t model;
+			uint8_t attachment;
+			uint8_t model;
 
 			uint16_t field2;
 			uint16_t field3;
@@ -87,7 +90,8 @@ struct __packed tm_wheel_response
 		struct __packed {
 			uint16_t field0;
 			uint16_t field1;
-			uint16_t model;
+			uint8_t attachment;
+			uint8_t model;
 		} b;
 	} data;
 };


### PR DESCRIPTION
Hi, an issue was recently opened over at https://github.com/Kimplul/hid-tmff2/issues/28 where it was noted that if the T300 base has a different attachment than the default, `hid-tminit` wouldn't initialize the wheel. After looking at what we initially thought to be just model IDs, I think the upper byte (in big endian, i.e. 0x0206 for example) is actually the base ID, and the lower byte is the attachment ID. This commit changes the init to work only based on the base of the wheel, but leaves the attachment IDs as I'm not sure if different attachments need special handling.

Seems to work with my wheel with the default attachment and @ReazerDev's wheel with the F1 attachment. Would probably be good to check if the T150 etc still work, although I'm pretty sure they do.